### PR TITLE
fix: Fix types of useSessionStorage not reflecting SetStateAction

### DIFF
--- a/src/useSessionStorage.ts
+++ b/src/useSessionStorage.ts
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { isBrowser } from './misc/util';
 
 const useSessionStorage = <T>(
   key: string,
   initialValue?: T,
   raw?: boolean
-): [T, (value: T) => void] => {
+): [T, Dispatch<SetStateAction<T>>] => {
   if (!isBrowser) {
     return [initialValue as T, () => {}];
   }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change along with relevant motivation and context. -->


## Type of change

<!-- Check all relevant options. -->
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] **Breaking change** _(fix or feature that would cause existing functionality to not work as before)_

# Checklist
- [ ] Read the [Contributing Guide](https://github.com/streamich/react-use/blob/master/CONTRIBUTING.md)
- [x] Perform a code self-review
- [ ] Comment the code, particularly in hard-to-understand areas
- [ ] Add documentation
- [ ] Add hook's story at Storybook
- [ ] Cover changes with tests
- [x] Ensure the test suite passes (`yarn test`)
- [ ] Provide 100% tests coverage
- [x] Make sure code lints (`yarn lint`). Fix it with `yarn lint:fix` in case of failure.
- [x] Make sure types are fine (`yarn lint:types`).

<!-- If you can't check all the checkboxes right now - check what you can, create a Draft PR, make some changes if needed and get back to it when you will be able to put some marks in list. -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.5.2--canary.3.2795331418.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @opencreek/react-use@17.5.2--canary.3.2795331418.0
  # or 
  yarn add @opencreek/react-use@17.5.2--canary.3.2795331418.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
